### PR TITLE
Fix 500 errors on channel setup with multi-orgs

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -32,9 +32,11 @@
          'akeneoCurrenciesSelector':'select[name="%s"]'|format(form.akeneoActiveCurrencies.vars.full_name),
          'channelId': form.vars.value.channel.id|default(0),
          'akeneoCurrenciesSelector':'select[name="%s"]'|format(form.akeneoActiveCurrencies.vars.full_name),
-         'backendUrl': path('oro_akeneo_validate_connection', {'channelId': form.vars.value.channel.id|default(0) })
-     }|json_encode }}"
->
+         'backendUrl': path('oro_akeneo_validate_connection', {
+             'channelId': form.vars.value.channel.id|default(0),
+             '_sa_org_id': form.parent.organization.value|default(null)
+         }
+     }|json_encode }}">
 
     <div id="check_akeneo_required_fields">
         <div class="control-group control-group-choice">


### PR DESCRIPTION
When an application was set up with multi-organizations, we had issues configuring an Akeneo integration, a POST request on `/admin/akeneo-validate/validate-akeneo-connection/0/`
 URI produces a 302 redirect to `/admin/organization/selector?form_url=http%3A//localhost%3A8000/index_dev.php/admin/akeneo-validate/validate-akeneo-connection/0/`

![image (5)](https://user-images.githubusercontent.com/152367/55474600-dd600100-5611-11e9-8892-72e9a57266db.png)

As the first request is required to be a `POST`, the redirection loop couldn't succeed. To fix it, I needed to add the `_sa_org_id` parameter to the first request (value defined during the first-step form of the integration, and then set up in a read-only field).