### PR TITLE
Fix edge case described in issue #6

### DIFF
--- a/ImportExport/DataConverter/ProductDataConverter.php
+++ b/ImportExport/DataConverter/ProductDataConverter.php
@@ -375,9 +375,13 @@ class ProductDataConverter extends BaseProductDataConverter implements ContextAw
      *
      * @return string
      */
-    private function processFileType(array $value): string
+    private function processFileType(array $value): ?string
     {
         $item = array_shift($value);
+        
+        if ($item === null) {
+            return null;
+        }
 
         return $this->getAttachmentPath($item['data']);
     }


### PR DESCRIPTION
An exception occurs when an image URI is empty, or image meta data is inconsistent.

See issue #6 