### PR TITLE
BUGFIX  + Break Compatibility change: fix an issue with attributes no…

### DIFF
--- a/ImportExport/Strategy/AttributeImportStrategy.php
+++ b/ImportExport/Strategy/AttributeImportStrategy.php
@@ -123,12 +123,6 @@ class AttributeImportStrategy extends EntityFieldImportStrategy
             ) {
                 return null;
             }
-
-            // Field should get new fieldName @BC: Akeneo_Aken_1706289854 to Akeneo_bran_1706289854
-            $fieldName = FieldConfigModelFieldNameGenerator::generate(
-                sprintf('%s_%s', $entity->getFieldName(), $entity->getType())
-            );
-            $entity->setFieldName($fieldName);
         }
 
         return $entity;


### PR DESCRIPTION
…t assigned to a family when the attributes has relations and its name is too long. The attribute code generated differ in AttributeImportStrategy and AttributeFamilyImportStrategy. It's a BC because on an existing installation, existing attributes may be duplicated with a different attribute code.