### PR TITLE
FEATURE: add support of an alternative akeneo identifier. For example…

### DIFF
--- a/Entity/AkeneoSettings.php
+++ b/Entity/AkeneoSettings.php
@@ -681,5 +681,5 @@ class AkeneoSettings extends Transport
         $this->alternativeIdentifier = $alternativeIdentifier;
 
         return $this;
-}
+    }
 }

--- a/Entity/AkeneoSettings.php
+++ b/Entity/AkeneoSettings.php
@@ -162,6 +162,13 @@ class AkeneoSettings extends Transport
     private $akeneoMergeImageToParent = false;
 
     /**
+     * @var string|null
+     *
+     * @ORM\Column(name="akeneo_alternative_identifier", type="string", nullable=true, length=255)
+     */
+    private $alternativeIdentifier;
+
+    /**
      * @var ParameterBag
      */
     private $settings;
@@ -655,4 +662,24 @@ class AkeneoSettings extends Transport
 
         return $this;
     }
+
+    /**
+     * @return string|null
+     */
+    public function getAlternativeIdentifier(): ?string
+    {
+        return $this->alternativeIdentifier;
+    }
+
+    /**
+     * @param string|null $alternativeIdentifier
+     *
+     * @return $this
+     */
+    public function setAlternativeIdentifier(?string $alternativeIdentifier): self
+    {
+        $this->alternativeIdentifier = $alternativeIdentifier;
+
+        return $this;
+}
 }

--- a/Form/Type/AkeneoSettingsType.php
+++ b/Form/Type/AkeneoSettingsType.php
@@ -6,6 +6,7 @@ use Oro\Bundle\AkeneoBundle\Encoder\Crypter;
 use Oro\Bundle\AkeneoBundle\Entity\AkeneoSettings;
 use Oro\Bundle\AkeneoBundle\Integration\AkeneoTransportInterface;
 use Oro\Bundle\AkeneoBundle\Settings\DataProvider\SyncProductsDataProviderInterface;
+use Oro\Bundle\AkeneoBundle\Validator\Constraints\AlternativeIdentifierConstraint;
 use Oro\Bundle\AkeneoBundle\Validator\Constraints\AttributeCodeConstraint;
 use Oro\Bundle\AkeneoBundle\Validator\Constraints\JsonConstraint;
 use Oro\Bundle\CatalogBundle\Entity\Category;
@@ -176,6 +177,17 @@ class AkeneoSettingsType extends AbstractType implements LoggerAwareInterface
                     'label'             => false,
                     'multiple'          => true,
                     'choices'           => [],
+                ]
+            )
+            ->add(
+                'alternativeIdentifier',
+                TextType::class,
+                [
+                    'label'    => 'oro.akeneo.integration.settings.alternative_identifier.label',
+                    'required' => false,
+                    'constraints' => [
+                        new AlternativeIdentifierConstraint(),
+                    ]
                 ]
             )
             ->add(

--- a/Integration/AkeneoTransport.php
+++ b/Integration/AkeneoTransport.php
@@ -253,5 +253,4 @@ class AkeneoTransport implements AkeneoTransportInterface
     {
         return $this->transportEntity->getAlternativeIdentifier();
     }
-
 }

--- a/Integration/AkeneoTransport.php
+++ b/Integration/AkeneoTransport.php
@@ -184,7 +184,8 @@ class AkeneoTransport implements AkeneoTransportInterface
             $this->client,
             $this->logger,
             $this->filesystem,
-            $this->getAttributes($pageSize)
+            $this->getAttributes($pageSize),
+            $this->getAlternativeIdentifier()
         );
     }
 
@@ -247,4 +248,10 @@ class AkeneoTransport implements AkeneoTransportInterface
 
         return new AttributeIterator($this->client->getAttributeApi()->all($pageSize), $this->client, $this->logger, $attributeFilter);
     }
+
+    private function getAlternativeIdentifier(): ?string
+    {
+        return $this->transportEntity->getAlternativeIdentifier();
+    }
+
 }

--- a/Integration/Iterator/ProductIterator.php
+++ b/Integration/Iterator/ProductIterator.php
@@ -97,15 +97,14 @@ class ProductIterator extends AbstractIterator
      */
     protected function setAlternativeIdentifier(array &$product): void
     {
-        if (null === $this->alternativeAttribute) return;
+        if (null === $this->alternativeAttribute) {
+            return;
+        }
 
         @list($altAttribute, $identifier) = explode(':', $this->alternativeAttribute);
 
-        if (!empty($altAttribute)
-            && isset($product['values'][$altAttribute])
-            && isset($product['identifier'])
+        if (!empty($altAttribute) && isset($product['values'][$altAttribute]) && isset($product['identifier'])
         ) {
-
             if (isset($product['values'][$altAttribute][0]['data'])) {
                 if (null !== $identifier) {
                     $product[$identifier] = $product['identifier'];

--- a/Migrations/Schema/OroAkeneoBundleInstaller.php
+++ b/Migrations/Schema/OroAkeneoBundleInstaller.php
@@ -48,7 +48,7 @@ class OroAkeneoBundleInstaller implements Installation, ExtendExtensionAwareInte
      */
     public function getMigrationVersion()
     {
-        return 'v1_6';
+        return 'v1_7';
     }
 
     /**
@@ -114,6 +114,7 @@ class OroAkeneoBundleInstaller implements Installation, ExtendExtensionAwareInte
         $table->addColumn('akeneo_attributes_list', 'text', ['notnull' => false]);
         $table->addColumn('rootcategory_id', 'integer', ['notnull' => false]);
         $table->addColumn('pricelist_id', 'integer', ['notnull' => false]);
+        $table->addColumn('akeneo_alternative_identifier', 'string', ['notnull' => false,'length' => 255]);
         $table->addColumn('akeneo_attributes_image_list', 'text', ['notnull' => false]);
         $table->addColumn('akeneo_merge_image_to_parent', 'boolean', ['notnull' => false]);
         $table->addIndex(['rootcategory_id'], 'idx_d7a389a852d2453c', []);

--- a/Migrations/Schema/v1_7/OroAkeneoMigration.php
+++ b/Migrations/Schema/v1_7/OroAkeneoMigration.php
@@ -10,7 +10,7 @@ use Oro\Bundle\MigrationBundle\Migration\QueryBag;
  * @SuppressWarnings(PHPMD.TooManyMethods)
  * @SuppressWarnings(PHPMD.ExcessiveClassLength)
  */
-class OroAkeneoBundleInstaller implements Migration
+class OroAkeneoMigration implements Migration
 {
     /**
      * {@inheritdoc}

--- a/Migrations/Schema/v1_7/OroAkeneoMigration.php
+++ b/Migrations/Schema/v1_7/OroAkeneoMigration.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Oro\Bundle\AkeneoBundle\Migrations\Schema\v1_7;
+
+use Doctrine\DBAL\Schema\Schema;
+use Oro\Bundle\MigrationBundle\Migration\Migration;
+use Oro\Bundle\MigrationBundle\Migration\QueryBag;
+
+/**
+ * @SuppressWarnings(PHPMD.TooManyMethods)
+ * @SuppressWarnings(PHPMD.ExcessiveClassLength)
+ */
+class OroAkeneoBundleInstaller implements Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getMigrationVersion()
+    {
+        return 'v1_7';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function up(Schema $schema, QueryBag $queries)
+    {
+        /** Tables generation **/
+        $this->updateOroIntegrationTransportTable($schema);
+    }
+
+    /**
+     * Create oro_integration_transport table
+     */
+    protected function updateOroIntegrationTransportTable(Schema $schema)
+    {
+        $table = $schema->getTable('oro_integration_transport');
+        $table->addColumn('akeneo_alternative_identifier', 'string', ['notnull' => false,'length' => 255]);
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -63,6 +63,11 @@ services:
     tags:
       - { name: validator.constraint_validator, alias: oro_akeneo.attribute_code_validator }
 
+  oro_akeneo.validator.alternative_identifier_validator:
+    class: Oro\Bundle\AkeneoBundle\Validator\AlternativeIdentifierValidator
+    tags:
+      - { name: validator.constraint_validator, alias: oro_akeneo.alternative_identifier_validator }
+
   oro_akeneo.event_subscriber.doctrine:
     class: 'Oro\Bundle\AkeneoBundle\EventSubscriber\DoctrineSubscriber'
     calls:

--- a/Resources/translations/messages.en.yml
+++ b/Resources/translations/messages.en.yml
@@ -49,6 +49,9 @@ oro:
         merge_image:
           label: 'Merge images from simple products to configurable product'
           tooltip: 'Add all images from the children to the configurable product'
+        alternative_identifier:
+          label: 'Alternative identifier'
+          tooltip: 'Use a different attribute as the original identifier attribute provided by Akeneo. Set the attribute code name of Akeneo here. e.g. "my_sku". If you want to keep the old identifier, provide is Akeneo code like this: new_identifier:old_identifier. The old identifier code must be the same code existing in Akeneo and must be present into the Attribute filter list if any.'
       popup:
         channel: 'This is a list of channels configured for the current Akeneo PIM instance. Select the required channel for product and category import. To refresh the list, click Refresh Channels'
         currencies: 'The control configures mapping between the currencies enabled in the current Akeneo PIM instance and the currencies enabled in this application. To skip price import for a specific currency, do not add mapping to it. To refresh the list, click Refresh Currencies'

--- a/Resources/translations/validators.en.yml
+++ b/Resources/translations/validators.en.yml
@@ -4,3 +4,5 @@ oro.akeneo:
       message: 'Product filter is invalid. Please make sure it uses a valid JSON format.'
     attribute_code:
       message: 'Only letters, numbers and underscores and semi colon for separator are allowed.'
+    alternative_identifier:
+      message: 'Only letters, digits, underscore or ":" character is allowed'

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -97,6 +97,16 @@
                 </div>
             </div>
 
+            <div class="control-group control-group-choice">
+                <div class="control-label wrap">
+                    {{ UI.tooltip('oro.akeneo.integration.settings.alternative_identifier.tooltip'|trans, {}, 'right') }}
+                    {{ form_label(form.alternativeIdentifier) }}
+                </div>
+                <div class="controls">
+                    {{ form_widget(form.alternativeIdentifier) }}
+                </div>
+            </div>
+
             {{ form_row(form.syncProducts) }}
 
             <div class="control-group control-group-choice">

--- a/Validator/AlternativeIdentifierValidator.php
+++ b/Validator/AlternativeIdentifierValidator.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Oro\Bundle\AkeneoBundle\Validator;
+
+use Oro\Bundle\AkeneoBundle\Validator\Constraints\AlternativeIdentifierConstraint;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class AlternativeIdentifierValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        /* @var AlternativeIdentifierConstraint $constraint */
+        if (!$this->isValid($value) && !empty($value)) {
+            $this->context->addViolation($constraint->message);
+        }
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return bool
+     */
+    private function isValid($value)
+    {
+        preg_match_all('/([^a-zA-Z0-9_:])/m', $value, $matches, PREG_SET_ORDER, 0);
+
+        return count($matches) == 0;
+    }
+}

--- a/Validator/Constraints/AlternativeIdentifierConstraint.php
+++ b/Validator/Constraints/AlternativeIdentifierConstraint.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Oro\Bundle\AkeneoBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+class AlternativeIdentifierConstraint extends Constraint
+{
+    /**
+     * @var string
+     */
+    public $message = 'oro.akeneo.validator.alternative_identifier.message';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validatedBy()
+    {
+        return 'oro_akeneo.alternative_identifier_validator';
+    }
+}


### PR DESCRIPTION
…, if the identifier in akeneo is 'ean' but you want to use the attribute 'my_sku' as 'sku' in Oro. You can still keep the ean to be created as an attribute in orocommerce and set the my_sku as sku in orocommerce