### PR TITLE
Change ProductImageType import strategy

### DIFF
--- a/ImportExport/Processor/ProductImageImportProcessor.php
+++ b/ImportExport/Processor/ProductImageImportProcessor.php
@@ -88,14 +88,14 @@ class ProductImageImportProcessor extends StepExecutionAwareImportProcessor
         }
 
         if (!$hasMain) {
-            if ($product->getImages()->last()) {
-                $product->getImages()->last()->addType(ProductImageType::TYPE_MAIN);
+            if ($product->getImages()->first()) {
+                $product->getImages()->first()->addType(ProductImageType::TYPE_MAIN);
             }
         }
 
         if (!$hasListing) {
-            if ($product->getImages()->last()) {
-                $product->getImages()->last()->addType(ProductImageType::TYPE_LISTING);
+            if ($product->getImages()->first()) {
+                $product->getImages()->first()->addType(ProductImageType::TYPE_LISTING);
             }
         }
 


### PR DESCRIPTION
Set the first image coming from the Akeneo API for a product because the array of attributes is sorted alphabetically, he is coming like this  :

`array (
  'image1' => 'main.jpg',
  'image2' => 'second.jpg'
)`
so it make sense to set the first image as main one.

