### PR TITLE
remove 'completeness' filter from product-models api calls

### DIFF
--- a/Integration/AkeneoTransport.php
+++ b/Integration/AkeneoTransport.php
@@ -212,6 +212,9 @@ class AkeneoTransport implements AkeneoTransportInterface
         $this->initFamilyVariants();
 
         $searchFilters = $this->akeneoSearchBuilder->getFilters($this->transportEntity->getProductFilter());
+        if (isset($searchFilters['completeness'])) {
+            unset($searchFilters['completeness']);
+        }
 
         return new ProductIterator(
             $this->client->getProductModelApi()->all(


### PR DESCRIPTION
Remove 'completeness' filter from product model Api call because the filter is shared between both product and product models api calls.
Akeneo does not return any product model if 'completeness' is used as a filter on '/api/rest/v1/product-models'