### PR TITLE
Update ProductDataConverter.php

### DIFF
--- a/ImportExport/DataConverter/ProductDataConverter.php
+++ b/ImportExport/DataConverter/ProductDataConverter.php
@@ -55,6 +55,17 @@ class ProductDataConverter extends BaseProductDataConverter implements ContextAw
 
     /** @var ProductVariantFieldValueHandlerRegistry */
     private $productVariantFieldValueHandlerRegistry;
+    
+    /** @var ContextInterface */
+    protected $context;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setImportExportContext(ContextInterface $context)
+    {
+        $this->context = $context;
+    }
 
     public function setDoctrineHelper(DoctrineHelper $doctrineHelper)
     {


### PR DESCRIPTION
Upon installing the following issue comes up:

Fixing:

  PHP Fatal error:  Class Oro\Bundle\AkeneoBundle\ImportExport\DataConverter\ProductDataConverter contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Oro\Bundle\ImportExportBundl
  e\Context\ContextAwareInterface::setImportExportContext) in /app/vendor/oro/commerce-akeneo/ImportExport/DataConverter/ProductDataConverter.php on line 28