### PR TITLE
Delete organization attribute config on synchronization

### DIFF
--- a/ImportExport/Writer/AttributeWriter.php
+++ b/ImportExport/Writer/AttributeWriter.php
@@ -278,8 +278,8 @@ class AttributeWriter extends BaseAttributeWriter implements StepExecutionAwareI
 
         $attributeConfig->set('field_name', $fieldName);
         $attributeConfig->set('is_attribute', true);
-        $attributeConfig->set('is_global', false);
-        $attributeConfig->set('organization_id', $this->getOrganizationId());
+        $attributeConfig->set('is_global', true);
+        $attributeConfig->remove('organization_id');
         $this->configManager->persist($attributeConfig);
 
         parent::setAttributeData($fieldConfigModel);
@@ -313,26 +313,6 @@ class AttributeWriter extends BaseAttributeWriter implements StepExecutionAwareI
         $importExportConfig->set('fallback_field', $fieldType);
         $this->configManager->persist($extendConfig);
         $this->configManager->persist($importExportConfig);
-    }
-
-    private function getOrganizationId(): ?int
-    {
-        if (!$this->organizationId) {
-            $channelId = $this->stepExecution->getJobExecution()->getExecutionContext()->get('channel');
-            if (!$channelId) {
-                return null;
-            }
-
-            /** @var Channel $channel */
-            $channel = $this->doctrineHelper->getEntity(Channel::class, $channelId);
-            if (!$channel) {
-                return null;
-            }
-
-            $this->organizationId = $channel->getOrganization()->getId();
-        }
-
-        return $this->organizationId;
     }
 
     private function saveDatagridConfig(string $className, string $fieldName): void


### PR DESCRIPTION
In the actual state of the attribute connector, if we have multiple organization with different oroakeneo integration with some common attributes between organizations. The scope of the organization will change everytime, at every synchronization.
So iIsuggest to remove the organization restriction to be able to access attributes everywhere.

To make it work, it is necessary to apply this patch :
```

--- vendor/oro/platform/src/Oro/Bundle/EntityConfigBundle/Config/ConfigManager.php	2022-05-16 14:05:26.000000000 +0200
+++ vendor/oro/platform/src/Oro/Bundle/EntityConfigBundle/Config/ConfigManager.php	2022-05-16 12:29:12.000000000 +0200
@@ -1244,6 +1244,8 @@
                     if ($originalValue != $value) {
                         $diff[$code] = [$originalValue, $value];
                     }
+                } else {
+                    $diff[$code] = [$originalValue, null];
                 }
             }
             foreach ($values as $code => $value) {

```
