### PR TITLE
Fixed `PrimaryUnitPrecision` set logic

### DIFF
--- a/ImportExport/DataConverter/ProductDataConverter.php
+++ b/ImportExport/DataConverter/ProductDataConverter.php
@@ -79,9 +79,9 @@ class ProductDataConverter extends BaseProductDataConverter implements ContextAw
 
         $this->processValues($importedRecord);
         $this->processSystemValues($importedRecord);
+        $this->setPrimaryUnitPrecision($importedRecord);
         unset($importedRecord['values']);
 
-        $this->setPrimaryUnitPrecision($importedRecord);
         $this->setStatus($importedRecord);
         $this->setCategory($importedRecord);
         $this->setFamilyVariant($importedRecord);

--- a/Integration/AkeneoSearchBuilder.php
+++ b/Integration/AkeneoSearchBuilder.php
@@ -35,9 +35,9 @@ class AkeneoSearchBuilder
                             $option['operator'],
                             $option['value'],
                             array_merge(
-                                (isset($option['scope']) ? ['scope' => $option['scope']] : []),
-                                (isset($option['locale']) ? ['locale' => $option['locale']] : []),
-                                (isset($option['locales']) ? ['locales' => $option['locales']] : [])
+                                isset($option['scope']) ? ['scope' => $option['scope']] : [],
+                                isset($option['locale']) ? ['locale' => $option['locale']] : [],
+                                isset($option['locales']) ? ['locales' => $option['locales']] : []
                             )
                         );
                 }


### PR DESCRIPTION
`$this->setPrimaryUnitPrecision($importedRecord);` should be called before `unset($importedRecord['values']);`
for reason `setPrimaryUnitPrecision` uses `$importedRecord['values']` array internally.