### PR TITLE
Link Akeneo priority to enum value priority

### DIFF
--- a/ImportExport/DataConverter/AttributeDataConverter.php
+++ b/ImportExport/DataConverter/AttributeDataConverter.php
@@ -113,6 +113,8 @@ class AttributeDataConverter extends EntityFieldDataConverter
         $defaultLocale = $transport->getMappedAkeneoLocale($defaultLocalization->getLanguageCode());
 
         foreach ($importedRecord['options'] as $key => &$option) {
+            $optionKey = sprintf('enum.enum_options.%d.priority', $key);
+            $importedRecord[$optionKey] = $option['sort_order'];
             $optionKey = sprintf('enum.enum_options.%d.id', $key);
             $importedRecord[$optionKey] = Generator::generateLabel($option['code']);
             $optionKey = sprintf('enum.enum_options.%d.label', $key);


### PR DESCRIPTION
Import the priority of an Akeneo attribute option so it can be used for sorting purposes.